### PR TITLE
Adds support for names with digits in them.

### DIFF
--- a/Saquib.Utils.Naming.Tests/CamelCaseNamingStrategyTests.cs
+++ b/Saquib.Utils.Naming.Tests/CamelCaseNamingStrategyTests.cs
@@ -5,12 +5,13 @@ namespace Saquib.Utils.Naming {
         private readonly CamelCaseNamingStrategy _strategy = new CamelCaseNamingStrategy();
 
         [Theory]
-        [InlineData( "lastModifiedDate" )]
-        [InlineData( "LastModifiedDate" )]
-        [InlineData( "last-modified-date" )]
-        [InlineData( "last_modified_date" )]
+        [InlineData( "last22modifiedDate" )]
+        [InlineData( "last22ModifiedDate" )]
+        [InlineData( "Last22ModifiedDate" )]
+        [InlineData( "last-22-modified-date" )]
+        [InlineData( "last_22_modified_date" )]
         public void Apply( string input ) {
-            var expected = "lastModifiedDate";
+            var expected = "last22ModifiedDate";
 
             var actual = _strategy.Apply( input );
 

--- a/Saquib.Utils.Naming.Tests/NameSplitterTests.cs
+++ b/Saquib.Utils.Naming.Tests/NameSplitterTests.cs
@@ -8,8 +8,22 @@ namespace Saquib.Utils.Naming {
         [InlineData( "LastModifiedDate" )]
         [InlineData( "last-modified-date" )]
         [InlineData( "last_modified_date" )]
-        public void Split( string input ) {
+        public void Split__SimpleNames( string input ) {
             var expected = new[] { "last", "modified", "date" };
+
+            var parts = NameSplitter.Split( input );
+
+            Assert.Equal( expected, parts );
+        }
+
+        [Theory]
+        [InlineData( "last222modifiedDates" )]
+        [InlineData( "last222ModifiedDates" )]
+        [InlineData( "Last222ModifiedDates" )]
+        [InlineData( "last-222-modified-dates" )]
+        [InlineData( "last_222_modified_dates" )]
+        public void Split__WithNumbers( string input ) {
+            var expected = new[] { "last", "222", "modified", "dates" };
 
             var parts = NameSplitter.Split( input );
 

--- a/Saquib.Utils.Naming.Tests/PascalCaseNamingStrategyTests.cs
+++ b/Saquib.Utils.Naming.Tests/PascalCaseNamingStrategyTests.cs
@@ -5,12 +5,13 @@ namespace Saquib.Utils.Naming {
         private readonly PascalCaseNamingStrategy _strategy = new PascalCaseNamingStrategy();
 
         [Theory]
-        [InlineData( "lastModifiedDate" )]
-        [InlineData( "LastModifiedDate" )]
-        [InlineData( "last-modified-date" )]
-        [InlineData( "last_modified_date" )]
+        [InlineData( "last22modifiedDate" )]
+        [InlineData( "last22ModifiedDate" )]
+        [InlineData( "Last22ModifiedDate" )]
+        [InlineData( "last-22-modified-date" )]
+        [InlineData( "last_22_modified_date" )]
         public void Apply( string input ) {
-            var expected = "LastModifiedDate";
+            var expected = "Last22ModifiedDate";
 
             var actual = _strategy.Apply( input );
 

--- a/Saquib.Utils.Naming/CachedNamingStrategy.cs
+++ b/Saquib.Utils.Naming/CachedNamingStrategy.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Saquib.Utils.Naming {
+    /// <summary>
+    /// Caches all calls to the underlying naming strategy.
+    /// </summary>
+    public sealed class CachedNamingStrategy : NamingStrategy {
+        private readonly ConcurrentDictionary<string, string> _cache = new ConcurrentDictionary<string, string>();
+        private readonly NamingStrategy _inner;
+
+        public CachedNamingStrategy( NamingStrategy inner ) {
+            _inner = inner ?? throw new ArgumentNullException( nameof( inner ) );
+        }
+
+        public override string Apply( string name ) => _cache.GetOrAdd( name, _inner.Apply );
+    }
+}

--- a/Saquib.Utils.Naming/CamelCaseNamingStrategy.cs
+++ b/Saquib.Utils.Naming/CamelCaseNamingStrategy.cs
@@ -1,6 +1,12 @@
 using System.Linq;
 
 namespace Saquib.Utils.Naming {
+    /// <summary>
+    /// Converts a name using camel-casing rules.
+    /// </summary>
+    /// <remarks>
+    /// For example, `last_modified_to` is converted to `lastModifiedTo`.
+    /// </remarks>
     public sealed class CamelCaseNamingStrategy : NamingStrategy {
         public override string Apply( string name ) {
             var parts = SplitNames( name )

--- a/Saquib.Utils.Naming/PascalCaseNamingStrategy.cs
+++ b/Saquib.Utils.Naming/PascalCaseNamingStrategy.cs
@@ -1,6 +1,12 @@
 using System.Linq;
 
 namespace Saquib.Utils.Naming {
+    /// <summary>
+    /// Converts a name using Pascal-casing rules.
+    /// </summary>
+    /// <remarks>
+    /// For example, `last_modified_to` is converted to `LastModifiedTo`.
+    /// </remarks>
     public sealed class PascalCaseNamingStrategy : NamingStrategy {
         public override string Apply( string name ) {
             var parts = SplitNames( name )


### PR DESCRIPTION
Consecutive digits in a name are considered a single integer. So a name like `last22ModifiedDates` is split to `[last, 22, modified, dates]`.

The `NameSplitter` is refactored a little, to make it saner to add more splitting cases. This makes `NamingStrategy.Apply` more expensive, so a `CachedNamingStrategy` decorated is provided.